### PR TITLE
Add sample PDF directory and update paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ pip install -r requirements.txt
 ```
 
 ## 使い方
-1. `samples/`ディレクトリにAUTOSAR PDF（例: `AUTOSAR_RS_Diagnostics.pdf`）を配置
+1. `samples/`ディレクトリにAUTOSAR PDF（例: `AUTOSAR_RS_Diagnostics.pdf`）を配置する
+   - リポジトリには空ディレクトリを保持するため`.gitkeep`が含まれています
+   - スクリプトはこの`samples/`フォルダからPDFを読み込みます
 2. 以下のコマンドで実行
 
 ```sh

--- a/main.py
+++ b/main.py
@@ -5,8 +5,9 @@ from src.rs_parser import parse_requirement_block
 from src.output_writer import write_json
 from src.trace_parser import parse_trace_table
 from src.section_detector import detect_sections
+import os
 
-INPUT_PDF = "AUTOSAR_RS_Diagnostics.pdf"
+INPUT_PDF = os.path.join("samples", "AUTOSAR_RS_Diagnostics.pdf")
 OUTPUT_JSON_DIAG = "output/rs_diagnostics.json"
 OUTPUT_JSON_TRACE = "output/rs_trace.json"
 


### PR DESCRIPTION
## Summary
- add empty `samples` directory with `.gitkeep`
- update default input PDF path in `main.py` to read from `samples/`
- document new behaviour in `README`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`