### PR TITLE
Improve markitdown workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Python 3.8以降が必要です。
 
 ```sh
 pip install -r requirements.txt
+pip install markitdown  # markitdownがインストールされていない場合
 ```
 
 ## 使い方
@@ -33,6 +34,14 @@ pip install -r requirements.txt
 python3 main.py
 ```
 
+ヘッダとフッタを除去した上で [`markitdown`](https://github.com/yuukiw/markitdown)
+ を利用してJSON化する場合は次を実行します。
+
+```sh
+python3 markitdown_convert.py
+```
+
+- `output/rs_markitdown.json`：markitdown で変換した結果
 - `output/rs_diagnostics.json`：RS_Diag要件の抽出結果
 - `output/rs_trace.json`：RS_Mainトレース表の抽出結果
 

--- a/markitdown_convert.py
+++ b/markitdown_convert.py
@@ -1,0 +1,30 @@
+"""Convert PDF to JSON using markitdown after removing headers and footers."""
+
+import os
+import sys
+from src.pdf_parser import load_pdf
+from src.markitdown_wrapper import run_markitdown
+from src.output_writer import write_json
+
+INPUT_PDF = os.path.join("samples", "AUTOSAR_RS_Diagnostics.pdf")
+OUTPUT_JSON = "output/rs_markitdown.json"
+
+if __name__ == "__main__":
+    pdf_path = INPUT_PDF
+    out_path = OUTPUT_JSON
+
+    if len(sys.argv) > 1:
+        pdf_path = sys.argv[1]
+    if len(sys.argv) > 2:
+        out_path = sys.argv[2]
+
+    if not os.path.exists(pdf_path):
+        sys.exit(f"Input PDF not found: {pdf_path}")
+
+    pages = load_pdf(pdf_path, remove_header=True, remove_footer=True)
+    text = "\n".join(pages)
+
+    json_data = run_markitdown(text)
+
+    write_json(json_data, out_path)
+    print(f"Conversion completed -> {out_path}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyMuPDF==1.23.7          # PDFからテキスト・図・表の抽出に使用（fitz）
+markitdown

--- a/src/markitdown_wrapper.py
+++ b/src/markitdown_wrapper.py
@@ -1,0 +1,39 @@
+import json
+import subprocess
+import shutil
+from typing import Any
+
+
+def run_markitdown(text: str) -> Any:
+    """Run the ``markitdown`` CLI on the given text and return parsed JSON.
+
+    Parameters
+    ----------
+    text : str
+        The input text, typically Markdown, to feed into markitdown.
+
+    Returns
+    -------
+    Any
+        Parsed JSON object produced by markitdown.
+    """
+    if shutil.which("markitdown") is None:
+        raise FileNotFoundError("markitdown command not found. Install the markitdown package.")
+
+    result = subprocess.run(
+        ["markitdown", "--json"],
+        input=text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"markitdown failed with code {result.returncode}: {result.stderr.strip()}"
+        )
+
+    if not result.stdout.strip():
+        raise ValueError("markitdown produced no output")
+
+    return json.loads(result.stdout)

--- a/src/output_writer.py
+++ b/src/output_writer.py
@@ -1,9 +1,15 @@
 import json
 import os
 
-def write_json(data: list, output_path: str):
-    """
-    パース済みデータ（リスト）を JSON ファイルに保存する。
+def write_json(data, output_path: str):
+    """Serialize ``data`` to a JSON file.
+
+    Parameters
+    ----------
+    data : Any
+        JSON-serializable Python object.
+    output_path : str
+        Destination path for the JSON file.
     """
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, 'w', encoding='utf-8') as f:

--- a/src/pdf_parser.py
+++ b/src/pdf_parser.py
@@ -3,7 +3,14 @@
 import fitz  # PyMuPDF
 
 
-def load_pdf(path: str, *, remove_header: bool = False, header_margin: float = 50) -> list:
+def load_pdf(
+    path: str,
+    *,
+    remove_header: bool = False,
+    remove_footer: bool = False,
+    header_margin: float = 50,
+    footer_margin: float = 50,
+) -> list:
     """Load PDF pages as text.
 
     When ``remove_header`` is ``True``, the top ``header_margin`` points of each
@@ -18,8 +25,12 @@ def load_pdf(path: str, *, remove_header: bool = False, header_margin: float = 5
         Path to the PDF file.
     remove_header : bool, optional
         If ``True``, remove the header area from each page.
+    remove_footer : bool, optional
+        If ``True``, remove the footer area from each page.
     header_margin : float, optional
         Height in PDF points to exclude from the top of each page.
+    footer_margin : float, optional
+        Height in PDF points to exclude from the bottom of each page.
 
     Returns
     -------
@@ -30,11 +41,10 @@ def load_pdf(path: str, *, remove_header: bool = False, header_margin: float = 5
     doc = fitz.open(path)
     pages = []
     for page in doc:
-        if remove_header:
-            clip = fitz.Rect(0, header_margin, page.rect.width, page.rect.height)
-            text = page.get_text("text", clip=clip)
-        else:
-            text = page.get_text("text")
+        top = header_margin if remove_header else 0
+        bottom = page.rect.height - footer_margin if remove_footer else page.rect.height
+        clip = fitz.Rect(0, top, page.rect.width, bottom)
+        text = page.get_text("text", clip=clip)
         pages.append(text)
     return pages
 


### PR DESCRIPTION
## Summary
- add markitdown check and clearer errors
- allow markitdown_convert.py to take paths via CLI
- clarify markitdown installation in README
- document output_writer to accept any serializable data

## Testing
- `python3 -m compileall -q src markitdown_convert.py`
- `python3 markitdown_convert.py` *(fails: Input PDF not found)*