### PR TITLE
Add CLI main function and setup improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,16 @@ from setuptools import setup, find_packages
 setup(
     name="autosar-atlas-parser",
     version="0.1.0",
-    packages=find_packages(),
+    package_dir={"": "src"},
+    packages=find_packages("src"),
+    py_modules=["main"],
     install_requires=[
         # PDF処理に必要なライブラリをここに
         "pdfminer.six>=20221105"
     ],
     entry_points={
         "console_scripts": [
-            "autosar-parser=parse_pdf:main",  # parse_pdf.py に main() を実装していれば
+            "autosar-parser=main:main",
         ]
     }
 )

--- a/src/main.py
+++ b/src/main.py
@@ -1,15 +1,19 @@
 # coding: utf-8
-from src.pdf_parser import load_pdf
-from src.block_extractor import extract_blocks
-from src.rs_parser import parse_requirement_block
-from src.output_writer import write_json
-from src.trace_parser import parse_trace_table
-from src.section_detector import detect_sections
+from pdf_parser import load_pdf
+from block_extractor import extract_blocks
+from rs_parser import parse_requirement_block
+from output_writer import write_json
+from trace_parser import parse_trace_table
+from section_detector import detect_sections
+import argparse
 import os
 
 INPUT_PDF = os.path.join("samples", "AUTOSAR_RS_Diagnostics.pdf")
 OUTPUT_JSON_DIAG = "output/rs_diagnostics.json"
 OUTPUT_JSON_TRACE = "output/rs_trace.json"
+
+DEFAULT_INPUT_PDF = INPUT_PDF
+DEFAULT_OUTPUT_DIR = os.path.dirname(OUTPUT_JSON_DIAG)
 
 def extract_metadata(title_page_text):
     """
@@ -40,20 +44,41 @@ def extract_metadata(title_page_text):
             metadata["release_version"] = value
     return metadata
 
-if __name__ == "__main__":
+def main(args: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Parse AUTOSAR specification PDF")
+    parser.add_argument(
+        "pdf",
+        nargs="?",
+        default=DEFAULT_INPUT_PDF,
+        help="Input AUTOSAR PDF file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory to write output JSON files",
+    )
+    opts = parser.parse_args(args)
+
+    input_pdf = opts.pdf
+    output_dir = opts.output_dir
+    os.makedirs(output_dir, exist_ok=True)
+
+    out_diag = os.path.join(output_dir, os.path.basename(OUTPUT_JSON_DIAG))
+    out_trace = os.path.join(output_dir, os.path.basename(OUTPUT_JSON_TRACE))
+
     # Load full pages for section detection
-    pages_full = load_pdf(INPUT_PDF, remove_header=False)
+    pages_full = load_pdf(input_pdf, remove_header=False)
 
     # セクションをPDF内容から動的に検出
     # フォントサイズに基づく見出し解析で各セクションを特定する
-    ranges = detect_sections(pages_full, pdf_path=INPUT_PDF, return_indices=True)
+    ranges = detect_sections(pages_full, pdf_path=input_pdf, return_indices=True)
 
     # Load header-trimmed pages for actual parsing
-    pages = load_pdf(INPUT_PDF, remove_header=True)
+    pages = load_pdf(input_pdf, remove_header=True)
 
     (title_range, toc_range, doc_range, trace_range) = ranges
     title_section = pages[title_range[0]:title_range[1]]
-    toc_section = pages[toc_range[0]:toc_range[1]]
     doc_section = pages[doc_range[0]:doc_range[1]]
     trace_section = pages[trace_range[0]:trace_range[1]]
 
@@ -65,12 +90,16 @@ if __name__ == "__main__":
     metadata = extract_metadata(title_section[0])
     combined_output = {
         "metadata": metadata if any(metadata.values()) else None,
-        "requirements": diag_parsed
+        "requirements": diag_parsed,
     }
-    write_json(combined_output, OUTPUT_JSON_DIAG)
+    write_json(combined_output, out_diag)
 
     # RS_Main トレース表抽出
     trace_text = "\n".join(trace_section)
     trace_entries = parse_trace_table(trace_text)
-    write_json(trace_entries, OUTPUT_JSON_TRACE)
-    print(f"RS_Diag 抽出完了: {len(diag_parsed)} 件 → {OUTPUT_JSON_DIAG}")
+    write_json(trace_entries, out_trace)
+    print(f"RS_Diag 抽出完了: {len(diag_parsed)} 件 → {out_diag}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `main()` with argparse interface
- move script under `src` and update imports
- configure package for `src` layout and expose console script

## Testing
- `python setup.py develop --no-deps`
- `/root/.pyenv/versions/3.11.12/bin/autosar-parser sample.pdf` *(fails: cannot open empty document)*

------
https://chatgpt.com/codex/tasks/task_e_6840be754bfc8325b05d46ad6c580135